### PR TITLE
Fix for "TypeError: 'ellipsis' object is not iterable" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM ubuntu:xenial
 RUN apt-get update
-RUN apt-get install -y python3 python3-pip
+RUN apt-get install -y software-properties-common python-software-properties
+RUN add-apt-repository ppa:jonathonf/python-3.6
+RUN apt-get update
+RUN apt-get install -y python3.6 python3.6-dev python3.6-venv python3-pip
 
 ADD requirements.txt /opt/ethgasstation/requirements.txt
-RUN pip3 install -r /opt/ethgasstation/requirements.txt
+RUN python3.6 -m pip install -r /opt/ethgasstation/requirements.txt
 
 ADD settings.docker.conf /etc/ethgasstation.conf
 ADD . /opt/ethgasstation/
 ADD ethgasstation.py /opt/ethgasstation/ethgasstation.py
 
-CMD /usr/bin/python3 /opt/ethgasstation/ethgasstation.py
+CMD /usr/bin/python3.6 /opt/ethgasstation/ethgasstation.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 RUN apt-get update
 RUN apt-get install -y software-properties-common python-software-properties
-RUN add-apt-repository ppa:jonathonf/python-3.6
+RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update
 RUN apt-get install -y python3.6 python3.6-dev python3.6-venv python3-pip
 


### PR DESCRIPTION
Currently Docker version of **ethgasstation-backend** returns

```
Traceback (most recent call last):
  File "/opt/ethgasstation/ethgasstation.py", line 8, in <module>
    from egs.main import master_control
  File "/opt/ethgasstation/egs/main.py", line 7, in <module>
    from .egs_ref import *
  File "/opt/ethgasstation/egs/egs_ref.py", line 15, in <module>
    from hexbytes import HexBytes
  File "/usr/local/lib/python3.5/dist-packages/hexbytes/__init__.py", line 1, in <module>
    from .main import HexBytes  # noqa: F401
  File "/usr/local/lib/python3.5/dist-packages/hexbytes/main.py", line 1, in <module>
    from eth_utils import (
  File "/usr/local/lib/python3.5/dist-packages/eth_utils/__init__.py", line 24, in <module>
    from .applicators import (  # noqa: F401
  File "/usr/local/lib/python3.5/dist-packages/eth_utils/applicators.py", line 29, in <module>
    def combine_argument_formatters(*formatters: List[Callable[..., Any]]) -> Formatters:
  File "/usr/lib/python3.5/typing.py", line 1025, in __getitem__
    tvars = _type_vars(params)
  File "/usr/lib/python3.5/typing.py", line 284, in _type_vars
    _get_type_vars(types, tvars)
  File "/usr/lib/python3.5/typing.py", line 279, in _get_type_vars
    t._get_type_vars(tvars)
  File "/usr/lib/python3.5/typing.py", line 786, in _get_type_vars
    _get_type_vars(self.__args__, tvars)
  File "/usr/lib/python3.5/typing.py", line 277, in _get_type_vars
    for t in types:
TypeError: 'ellipsis' object is not iterable
```

when you try to run built container.

It's the issue of [Python 3.5.2](https://github.com/python/typing/issues/259) which is used in Ubuntu Xenial by default.
So with this PR we will use Python 3.6 to run the app.